### PR TITLE
Might be a bug in "hasattr(e, response)"

### DIFF
--- a/tornado_proxy/proxy.py
+++ b/tornado_proxy/proxy.py
@@ -69,7 +69,7 @@ class ProxyHandler(tornado.web.RequestHandler):
         try:
             client.fetch(req, handle_response)
         except tornado.httpclient.HTTPError, e:
-            if hasattr(e, response) and e.response:
+            if hasattr(e, 'response') and e.response:
                 self.handle_response(e.response)
             else:
                 self.set_status(500)


### PR DESCRIPTION
Thanks for sharing your excellent code. It works well in my case.

However, I might found a potential bug in the code.
Should the hasattr(e, response) use a string as its second parameter?
I just changed it to "hasattr(e, 'response')".
