### PR TITLE
Early client.close() and potential upstream.close() issue

### DIFF
--- a/tornado_proxy/proxy.py
+++ b/tornado_proxy/proxy.py
@@ -91,10 +91,18 @@ class ProxyHandler(tornado.web.RequestHandler):
         def read_from_upstream(data):
             client.write(data)
 
-        def client_close(_dummy):
+        def client_close(data=None):
+            if upstream.closed():
+                return
+            if data:
+                upstream.write(data)
             upstream.close()
 
-        def upstream_close(_dummy):
+        def upstream_close(data=None):
+            if client.closed():
+                return
+            if data:
+                client.write(data)
             client.close()
 
         def start_tunnel():


### PR DESCRIPTION
Despite the [docs on tornado.iostream.IOStream](http://www.tornadoweb.org/documentation/iostream.html#tornado.iostream.IOStream.read_until_close), under some circumstances read_until_close()'s handler does receive some leftover data.

Without the patch:

```
$ telnet localhost 8888
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
CONNECT httpbin.org:80 HTTP/1.0

HTTP/1.0 200 Connection established

GET /get HTTP/1.0
Host: httpbin.org

Connection closed by foreign host.
```

With the patch:

```
$ telnet localhost 8888
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
CONNECT httpbin.org:80 HTTP/1.0

HTTP/1.0 200 Connection established

GET /get HTTP/1.0
Host: httpbin.org

HTTP/1.1 200 OK
Content-Type: application/json
Date: Fri, 04 Jan 2013 02:45:50 GMT
Server: gunicorn/0.16.1
Content-Length: 155
Connection: Close

{
  "headers": {
    "Connection": "keep-alive",
    "Host": "httpbin.org"
  },
  "origin": "10.5.13.63",
  "args": {},
  "url": "http://httpbin.org/get"
}Connection closed by foreign host.
```

Mac OS X10.7.5
Python 2.7.1
Tornado 2.4.1
